### PR TITLE
fix: makes certfile and keyfile paths absolute

### DIFF
--- a/data/config.ini
+++ b/data/config.ini
@@ -62,8 +62,8 @@ ip_whitelist = *
 #uses the default one, which is fine because by default nobody should be
 # allowed to connect to your server or scan your packets
 #to generate another certificate see https://github.com/spesmilo/electrum-server/blob/ce1b11d7f5f7a70a3b6cc7ec1d3e552436e54ffe/HOWTO.md#step-8-create-a-self-signed-ssl-cert
-certfile = certs/cert.crt
-keyfile = certs/cert.key
+certfile = /data/certs/cert.crt
+keyfile = /data/certs/cert.key
 
 # Option for disabling the fee histogram calculation
 # It improves server responsiveness but stops mempool-based Electrum features


### PR DESCRIPTION
This is required, as relative paths will not work.
If file paths are relative, the eps will instead
load an internal resource cert/key file.

See  https://github.com/chris-belcher/electrum-personal-server/commit/4a5ae4df