### PR TITLE
updated electrum-personal-server to version 0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3-alpine
 LABEL maintainer="Tim Akinbo <tim@akinbo.org>"
 
 RUN set -ex && \
-    pip install https://github.com/chris-belcher/electrum-personal-server/archive/electrum-personal-server-v0.1.7.tar.gz#egg=electrum-personal-server
+    pip install https://github.com/chris-belcher/electrum-personal-server/archive/eps-v0.2.0.tar.gz#egg=electrum-personal-server
 
 VOLUME ["/data"]
 CMD ["electrum-personal-server", "/data/config.ini"]

--- a/data/config.ini
+++ b/data/config.ini
@@ -36,7 +36,7 @@ datadir =
 wallet_filename =
 
 # how often in seconds to poll for new transactions when electrum not connected
-poll_interval_listening = 30
+poll_interval_listening = 600
 # how often in seconds to poll for new transactions when electrum is connected
 poll_interval_connected = 5
 
@@ -72,10 +72,23 @@ disable_mempool_fee_histogram = false
 
 # Parameter for broadcasting unconfirmed transactions
 # Options are:
+# * tor-or-own-node  (use tor if tor is running locally, otherwise own-node)
 # * own-node         (broadcast using the connected full node)
+# * tor              (broadcast to random nodes over tor)
 # * system <cmd> %s  (save transaction to file, and invoke system command
 #                     with file path as parameter %s)
-broadcast_method = own-node
+broadcast_method = tor-or-own-node
+
+# For tor broadcasting (broadcast_method = tor) configure
+# the tor proxy host and port below
+tor_host = localhost
+tor_port = 9050
+
+# = Notes on tor broadcasting =
+# If using tor broadcasting, make sure you set `walletbroadcast=0` in
+#  your bitcoin.conf file
+# If your full node is connected to the internet only via tor then you dont
+#  need separate tor broadcasting
 
 
 [watch-only-addresses]
@@ -107,5 +120,6 @@ log_file_location =
 append_log = false
 
 # Format to use for logging messages
-#see docs https://docs.python.org/3/library/logging.html#logging.Formatter
+#see docs https://docs.python.org/3/library/logging.html#formatter-objects
 log_format = %(levelname)s:%(asctime)s: %(message)s
+


### PR DESCRIPTION
There is a more recent version 0.2.0 we should update to.

I also updated the config.ini template which only adds the new TOR options, corrects the absolute cert paths and sets poll_interval_listening to 600 (as was the default for eps-v0.2.0).